### PR TITLE
Update version to beta 6 to republish package with 'latest' npm release tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-ngx",
-  "version": "1.0.0-beta5",
+  "version": "1.0.0-beta6",
   "description": "This is a JavaScript module that can be used to easily include OneSignal code in a website or app that uses Angular for its front-end codebase.",
   "author": "rgomezp",
   "contributors": [{ "name": "Rodrigo Gomez-Palacio" }],


### PR DESCRIPTION
No change from version 5. Republishing since beta 4 was published with "latest" tag while beta 5 was published with "beta" tag. So version 5 is not the default install currently even though it contains the latest changes. We need to bump the version so that npm allows us to republish the package.